### PR TITLE
Added support for JSON/YAML datatypes

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "^.secrets.baseline$|go.sum|examples/SampleApp/go.sum|vendor",
     "lines": null
   },
-  "generated_at": "2021-07-01T06:28:41Z",
+  "generated_at": "2021-09-09T11:47:12Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -86,7 +86,7 @@
       }
     ]
   },
-  "version": "0.13.1+ibm.39.dss",
+  "version": "0.13.1+ibm.45.dss",
   "word_list": {
     "file": null,
     "hash": null

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ properties for distributed applications centrally.
 
 ## Installation
 
-The current version of this SDK: 0.1.1
+The current version of this SDK: 0.2.0
 
 There are a few different ways to download and install the IBM App Configuration Go SDK project for use by your Go
 application:
@@ -113,13 +113,15 @@ if err == nil {
 ## Get all features
 
 ```go
-features := appConfiguration.GetFeatures()
-feature := features["online-check-in"]
-
-fmt.Println("Feature Name", feature.GetFeatureName())
-fmt.Println("Feature Id", feature.GetFeatureID())
-fmt.Println("Feature Type", feature.GetFeatureDataType())
-fmt.Println("Feature is enabled", feature.IsEnabled())
+features, err := appConfiguration.GetFeatures()
+if err == nil {
+    feature := features["online-check-in"]
+    
+    fmt.Println("Feature Name", feature.GetFeatureName())
+    fmt.Println("Feature Id", feature.GetFeatureID())
+    fmt.Println("Feature Type", feature.GetFeatureDataType())
+    fmt.Println("Feature is enabled", feature.IsEnabled())
+}
 ```
 
 ## Evaluate a feature
@@ -151,12 +153,14 @@ if err == nil {
 ## Get all properties
 
 ```go
-properties := appConfiguration.GetProperties()
-property := properties["check-in-charges"]
-
-fmt.Println("Property Name", property.GetPropertyName())
-fmt.Println("Property Id", property.GetPropertyID())
-fmt.Println("Property Type", property.GetPropertyDataType())
+properties, err := appConfiguration.GetProperties()
+if err == nil {
+    property := properties["check-in-charges"]
+    
+    fmt.Println("Property Name", property.GetPropertyName())
+    fmt.Println("Property Id", property.GetPropertyID())
+    fmt.Println("Property Type", property.GetPropertyDataType())
+}
 ```
 
 ## Evaluate a property
@@ -173,6 +177,73 @@ entityAttributes["country"] = "India"
 
 propertyVal := property.GetCurrentValue(entityId, entityAttributes)
 ```
+
+## Supported Data types
+
+App Configuration service allows to configure the feature flag and properties in the following data types : Boolean,
+Numeric, String. The String data type can be of the format of a text string , JSON or YAML. The SDK processes each
+format accordingly as shown in the below table.
+<details><summary>View Table</summary>
+
+| **Feature or Property value**                                                                                      | **DataType** | **DataFormat** | **Type of data returned <br> by `GetCurrentValue()`** | **Example output**                                                   |
+| ------------------------------------------------------------------------------------------------------------------ | ------------ | -------------- | ----------------------------------------------------- | -------------------------------------------------------------------- |
+| `true`                                                                                                             | BOOLEAN      | not applicable | `bool`                                                | `true`                                                               |
+| `25`                                                                                                               | NUMERIC      | not applicable | `float64`                                             | `25`                                                                 |
+| "a string text"                                                                                                    | STRING       | TEXT           | `string`                                              | `a string text`                                                      |
+| <pre>{<br>  "firefox": {<br>    "name": "Firefox",<br>    "pref_url": "about:config"<br>  }<br>}</pre> | STRING       | JSON           | `map[string]interface{}`                              | `map[browsers:map[firefox:map[name:Firefox pref_url:about:config]]]` |
+| <pre>men:<br>  - John Smith<br>  - Bill Jones<br>women:<br>  - Mary Smith<br>  - Susan Williams</pre>  | STRING       | YAML           | `map[string]interface{}`                              | `map[men:[John Smith Bill Jones] women:[Mary Smith Susan Williams]]` |
+</details>
+
+<details><summary>Feature flag</summary>
+
+  ```go
+feature, err := appConfiguration.GetFeature("json-feature")
+if err == nil {
+    feature.GetFeatureDataType() // STRING
+    feature.GetFeatureDataFormat() // JSON
+    
+    // Example (traversing the returned map)
+    result := feature.GetCurrentValue(entityID, entityAttributes) // JSON value is returned as a Map
+    result.(map[string]interface{})["key"] // returns the value of the key
+}
+
+feature, err := appConfiguration.GetFeature("yaml-feature")
+if err == nil {
+    feature.GetFeatureDataType() // STRING
+    feature.GetFeatureDataFormat() // YAML
+    
+    // Example (traversing the returned map)
+    result := feature.GetCurrentValue(entityID, entityAttributes) // YAML value is returned as a Map
+    result.(map[string]interface{})["key"] // returns the value of the key
+}
+  ```
+
+</details>
+<details><summary>Property</summary>
+
+  ```go
+property, err := appConfiguration.GetProperty("json-property")
+if err == nil {
+    property.GetPropertyDataType() // STRING
+    property.GetPropertyDataFormat() // JSON
+
+    // Example (traversing the returned map)
+    result := property.GetCurrentValue(entityID, entityAttributes) // JSON value is returned as a Map
+    result.(map[string]interface{})["key"] // returns the value of the key
+}
+
+property, err := appConfiguration.GetProperty("yaml-property")
+if err == nil {
+    property.GetPropertyDataType() // STRING
+    property.GetPropertyDataFormat() // YAML
+
+    // Example (traversing the returned map)
+    result := property.GetCurrentValue(entityID, entityAttributes) // YAML value is returned as a Map
+    result.(map[string]interface{})["key"] // returns the value of the key
+}
+  ```
+
+</details>
 
 ## Set listener for feature or property data changes
 

--- a/examples/go.mod
+++ b/examples/go.mod
@@ -3,6 +3,6 @@ module examples
 go 1.16
 
 require (
-	github.com/IBM/appconfiguration-go-sdk v0.1.1
+	github.com/IBM/appconfiguration-go-sdk v0.2.0
 	github.com/gorilla/mux v1.7.2
 )

--- a/go.mod
+++ b/go.mod
@@ -15,4 +15,5 @@ require (
 	golang.org/x/text v0.3.6 // indirect
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20200605160147-a5ece683394c
 )

--- a/lib/AppConfiguration.go
+++ b/lib/AppConfiguration.go
@@ -152,12 +152,12 @@ func (ac *AppConfiguration) GetFeature(featureID string) (models.Feature, error)
 }
 
 // GetFeatures : Get Features
-func (ac *AppConfiguration) GetFeatures() map[string]models.Feature {
+func (ac *AppConfiguration) GetFeatures() (map[string]models.Feature, error) {
 	if ac.isInitializedConfig == true && ac.configurationHandlerInstance != nil {
 		return ac.configurationHandlerInstance.getFeatures()
 	}
 	log.Error(messages.CollectionInitError)
-	return nil
+	return nil, errors.New(messages.InitError)
 }
 
 // GetProperty : Get Property
@@ -170,12 +170,12 @@ func (ac *AppConfiguration) GetProperty(propertyID string) (models.Property, err
 }
 
 // GetProperties : Get Properties
-func (ac *AppConfiguration) GetProperties() map[string]models.Property {
+func (ac *AppConfiguration) GetProperties() (map[string]models.Property, error) {
 	if ac.isInitializedConfig == true && ac.configurationHandlerInstance != nil {
 		return ac.configurationHandlerInstance.getProperties()
 	}
 	log.Error(messages.CollectionInitError)
-	return nil
+	return nil, errors.New(messages.InitError)
 }
 
 // EnableDebug : Enable Debug

--- a/lib/ConfigurationHandler.go
+++ b/lib/ConfigurationHandler.go
@@ -232,11 +232,11 @@ func (ch *ConfigurationHandler) getFeatureActions(featureID string) (models.Feat
 	}
 	return models.Feature{}, errors.New(messages.ErrorInvalidFeatureID + featureID)
 }
-func (ch *ConfigurationHandler) getFeatures() map[string]models.Feature {
+func (ch *ConfigurationHandler) getFeatures() (map[string]models.Feature, error) {
 	if ch.cache == nil {
-		return map[string]models.Feature{}
+		return nil, errors.New(messages.InitError)
 	}
-	return ch.cache.FeatureMap
+	return ch.cache.FeatureMap, nil
 }
 func (ch *ConfigurationHandler) getFeature(featureID string) (models.Feature, error) {
 	if ch.cache != nil && len(ch.cache.FeatureMap) > 0 {
@@ -259,11 +259,11 @@ func (ch *ConfigurationHandler) getPropertyActions(propertyID string) (models.Pr
 	}
 	return models.Property{}, errors.New(messages.ErrorInvalidPropertyID + propertyID)
 }
-func (ch *ConfigurationHandler) getProperties() map[string]models.Property {
+func (ch *ConfigurationHandler) getProperties() (map[string]models.Property, error) {
 	if ch.cache == nil {
-		return map[string]models.Property{}
+		return nil, errors.New(messages.InitError)
 	}
-	return ch.cache.PropertyMap
+	return ch.cache.PropertyMap, nil
 }
 func (ch *ConfigurationHandler) getProperty(propertyID string) (models.Property, error) {
 	if ch.cache != nil && len(ch.cache.PropertyMap) > 0 {

--- a/lib/appconfiguration_test.go
+++ b/lib/appconfiguration_test.go
@@ -140,14 +140,14 @@ func TestGetFeature(t *testing.T) {
 func TestGetFeatures(t *testing.T) {
 	// test get features when not initialised properly
 	ac := GetInstance()
-	features := ac.GetFeatures()
-	assert.Nil(t, features)
+	_, err := ac.GetFeatures()
+	assert.Error(t, err, "Expected GetFeatures to return error")
 	reset(ac)
 
 	// test get features when config has been initialized properly and feature exists in the cache
 	mockInit(ac)
 	mockSetCache(ac)
-	features = ac.GetFeatures()
+	features, err := ac.GetFeatures()
 	if assert.NotNil(t, features) {
 		assert.Equal(t, "discountOnBikes", features["FID1"].Name)
 	}
@@ -171,17 +171,17 @@ func TestGetProperty(t *testing.T) {
 }
 
 func TestGetProperties(t *testing.T) {
-	// test get features when not initialised properly
+	// test get properties when not initialised properly
 	ac := GetInstance()
-	features := ac.GetProperties()
-	assert.Nil(t, features)
+	_, err := ac.GetProperties()
+	assert.Error(t, err, "Expected GetProperties to return error")
 	reset(ac)
-	// test get features when config has been initialized properly and feature exists in the cache
+	// test get properties when config has been initialized properly and property exists in the cache
 	mockInit(ac)
 	mockSetCache(ac)
-	features = ac.GetProperties()
-	if assert.NotNil(t, features) {
-		assert.Equal(t, "nodeReplica", features["PID1"].Name)
+	properties, err := ac.GetProperties()
+	if assert.NotNil(t, properties) {
+		assert.Equal(t, "nodeReplica", properties["PID1"].Name)
 	}
 	reset(ac)
 }

--- a/lib/configurationhandler_test.go
+++ b/lib/configurationhandler_test.go
@@ -289,12 +289,12 @@ func TestConfigHandlerGetProperties(t *testing.T) {
 	ch := GetConfigurationHandlerInstance()
 	data := `{"features":[{"name":"Cycle Rentals8","feature_id":"cycle-rentals8","type":"BOOLEAN","enabled_value":true,"disabled_value":false,"segment_rules":[],"enabled":true}],"properties":[{"name":"ShowAd","property_id":"show-ad","tags":"","type":"BOOLEAN","value":false,"segment_rules":[],"created_time":"2021-05-26T06:23:18Z","updated_time":"2021-06-08T03:38:38Z","evaluation_time":"2021-06-03T10:08:46Z"}],"segments":[{"name":"beta-users","segment_id":"knliu818","rules":[{"values":["ibm.com"],"operator":"contains","attribute_name":"email"}]},{"name":"ibm employees","segment_id":"ka761hap","rules":[{"values":["ibm.com","in.ibm.com"],"operator":"endsWith","attribute_name":"email"}]}]}`
 	ch.saveInCache(data)
-	val := ch.getProperties()
+	val, _ := ch.getProperties()
 	assert.Equal(t, "ShowAd", val["show-ad"].Name)
 
 	// when cache is
 	ch.cache = nil
-	val = ch.getProperties()
+	val, _ = ch.getProperties()
 	assert.Equal(t, 0, len(val))
 
 }
@@ -325,12 +325,12 @@ func TestConfigHandlerGetFeatures(t *testing.T) {
 	ch := GetConfigurationHandlerInstance()
 	data := `{"features":[{"name":"Cycle Rentals8","feature_id":"cycle-rentals8","type":"BOOLEAN","enabled_value":true,"disabled_value":false,"segment_rules":[],"enabled":true}],"properties":[{"name":"ShowAd","property_id":"show-ad","tags":"","type":"BOOLEAN","value":false,"segment_rules":[],"created_time":"2021-05-26T06:23:18Z","updated_time":"2021-06-08T03:38:38Z","evaluation_time":"2021-06-03T10:08:46Z"}],"segments":[{"name":"beta-users","segment_id":"knliu818","rules":[{"values":["ibm.com"],"operator":"contains","attribute_name":"email"}]},{"name":"ibm employees","segment_id":"ka761hap","rules":[{"values":["ibm.com","in.ibm.com"],"operator":"endsWith","attribute_name":"email"}]}]}`
 	ch.saveInCache(data)
-	val := ch.getFeatures()
+	val, _ := ch.getFeatures()
 	assert.Equal(t, "Cycle Rentals8", val["cycle-rentals8"].Name)
 
 	// when cache is nil
 	ch.cache = nil
-	val = ch.getFeatures()
+	val, _ = ch.getFeatures()
 	assert.Equal(t, 0, len(val))
 
 }

--- a/lib/internal/constants/constants.go
+++ b/lib/internal/constants/constants.go
@@ -23,4 +23,4 @@ const DefaultSegmentID = "$$null$$"
 const DefaultUsageLimit = 25
 
 // UserAgent specifies the user agent name
-const UserAgent = "appconfiguration-go-sdk/0.1.1"
+const UserAgent = "appconfiguration-go-sdk/0.2.0"

--- a/lib/internal/messages/Messages.go
+++ b/lib/internal/messages/Messages.go
@@ -208,6 +208,9 @@ const RetryWebSocketConnect = "Trying web socket connection again."
 // UnmarshalJSONErr : UnmarshalJSONErr const
 const UnmarshalJSONErr = "Error while unmarshalling JSON "
 
+// UnmarshalYAMLErr : UnmarshalYAMLErr const
+const UnmarshalYAMLErr = "Error while unmarshalling YAML "
+
 // MarshalJSONErr : MarshalJSONErr const
 const MarshalJSONErr = "Error while marshalling JSON "
 
@@ -216,3 +219,15 @@ const SetInMemoryCache = "Setting memory cache."
 
 // ConfigurationFileEmpty : ConfigurationFileEmpty const
 const ConfigurationFileEmpty = " file is empty."
+
+// InitError : Caused due to initialization error
+const InitError = "error: configurations not fetched, check the init and setcontext section for errors"
+
+// InvalidDataType : Invalid Datatype
+const InvalidDataType = "Invalid datatype: "
+
+// InvalidDataFormat : Invalid Data Format
+const InvalidDataFormat = "Invalid data format"
+
+// TypeCastingError : Type Casting Error
+const TypeCastingError = "Error Type casting. Check the feature or property values."

--- a/lib/internal/models/Feature.go
+++ b/lib/internal/models/Feature.go
@@ -31,6 +31,7 @@ type Feature struct {
 	Name          string        `json:"name"`
 	FeatureID     string        `json:"feature_id"`
 	DataType      string        `json:"type"`
+	Format        string        `json:"format"`
 	EnabledValue  interface{}   `json:"enabled_value"`
 	DisabledValue interface{}   `json:"disabled_value"`
 	SegmentRules  []SegmentRule `json:"segment_rules"`
@@ -44,11 +45,17 @@ func (f *Feature) GetFeatureName() string {
 
 // GetDisabledValue : Get Disabled Value
 func (f *Feature) GetDisabledValue() interface{} {
+	if f.Format == "YAML" {
+		return getTypeCastedValue(f.DisabledValue, f.GetFeatureDataType(), f.GetFeatureDataFormat())
+	}
 	return f.DisabledValue
 }
 
 // GetEnabledValue : Get Enabled Value
 func (f *Feature) GetEnabledValue() interface{} {
+	if f.Format == "YAML" {
+		return getTypeCastedValue(f.EnabledValue, f.GetFeatureDataType(), f.GetFeatureDataFormat())
+	}
 	return f.EnabledValue
 }
 
@@ -60,6 +67,16 @@ func (f *Feature) GetFeatureID() string {
 // GetFeatureDataType : Get Feature Data Type
 func (f *Feature) GetFeatureDataType() string {
 	return f.DataType
+}
+
+// GetFeatureDataFormat : Get Feature Data Format
+func (f *Feature) GetFeatureDataFormat() string {
+	// Format will be empty string ("") for Boolean & Numeric feature flags
+	// If the Format is empty for a String type, we default it to TEXT
+	if f.Format == "" && f.DataType == "STRING" {
+		f.Format = "TEXT"
+	}
+	return f.Format
 }
 
 // IsEnabled : Is Enabled
@@ -82,7 +99,7 @@ func (f *Feature) GetCurrentValue(entityID string, entityAttributes map[string]i
 
 	if f.isFeatureValid() {
 		val := f.featureEvaluation(entityID, entityAttributes)
-		return getTypeCastedValue(val, f.GetFeatureDataType())
+		return getTypeCastedValue(val, f.GetFeatureDataType(), f.GetFeatureDataFormat())
 	}
 	return nil
 }

--- a/lib/internal/models/models_test.go
+++ b/lib/internal/models/models_test.go
@@ -56,11 +56,13 @@ var feature = Feature{
 	DisabledValue: false,
 	Enabled:       true,
 	DataType:      "BOOLEAN",
+	Format:        "",
 	SegmentRules:  []SegmentRule{segmentRule},
 }
 
 var property = Property{
 	DataType:     "BOOLEAN",
+	Format:       "",
 	Name:         "propertyName",
 	PropertyID:   "propertyID",
 	Value:        true,
@@ -98,6 +100,9 @@ func TestFeature(t *testing.T) {
 	if feature.GetFeatureDataType() != "BOOLEAN" {
 		t.Error("Expected TestFeatureGetFeatureDataType test case to pass")
 	}
+	if feature.GetFeatureDataFormat() != "" {
+		t.Error("Expected TestFeatureGetFeatureDataFormat test case to pass")
+	}
 	if feature.GetEnabledValue() != true {
 		t.Error("Expected TestFeatureGetEnabledValue test case to pass")
 	}
@@ -116,12 +121,32 @@ func TestFeature(t *testing.T) {
 		t.Error("Expected TestFeatureGetCurrentValueBoolean test case to pass")
 	}
 	feature.DataType = "STRING"
+	feature.Format = "TEXT"
 	feature.EnabledValue = "EnabledValue"
 	feature.DisabledValue = "DisabledValue"
 	if feature.GetCurrentValue("entityID123", entityMap) != "EnabledValue" {
-		t.Error("Expected TestFeatureGetCurrentValueString test case to pass")
+		t.Error("Expected TestFeatureGetCurrentValueStringText test case to pass")
+	}
+	feature.DataType = "STRING"
+	feature.Format = "JSON"
+	enabledJSON := make(map[string]interface{})
+	enabledJSON["key"] = "enabled value"
+	feature.EnabledValue = enabledJSON
+	disabledJSON := make(map[string]interface{})
+	disabledJSON["key"] = "disabled value"
+	feature.DisabledValue = disabledJSON
+	if !reflect.DeepEqual(feature.GetCurrentValue("entityId123", entityMap), enabledJSON) {
+		t.Error("Expected TestFeatureGetCurrentValueStringJSON test case to pass")
+	}
+	feature.DataType = "STRING"
+	feature.Format = "YAML"
+	feature.EnabledValue = "men:\n  - John Smith\n  - Bill Jones\nwomen:\n  - Mary Smith\n  - Susan Williams"
+	feature.DisabledValue = "key:value"
+	if !reflect.DeepEqual(feature.GetCurrentValue("entityId123", entityMap), feature.GetEnabledValue()) {
+		t.Error("Expected TestFeatureGetCurrentValueStringYAML test case to pass")
 	}
 	feature.DataType = "NUMERIC"
+	feature.Format = ""
 	feature.EnabledValue = float64(1)
 	feature.DisabledValue = float64(0)
 	if feature.GetCurrentValue("entityID123", entityMap) != float64(1) {
@@ -168,6 +193,9 @@ func TestProperty(t *testing.T) {
 	if property.GetPropertyDataType() != "BOOLEAN" {
 		t.Error("Expected TestPropertyGetPropertyDataType test case to pass")
 	}
+	if property.GetPropertyDataFormat() != "" {
+		t.Error("Expected TestPropertyGetPropertyDataFormat test case to pass")
+	}
 	if property.GetValue() != true {
 		t.Error("Expected TestPropertyGetValue test case to pass")
 	}
@@ -180,11 +208,27 @@ func TestProperty(t *testing.T) {
 		t.Error("Expected TestPropertyGetCurrentValueBoolean test case to pass")
 	}
 	property.DataType = "STRING"
+	property.Format = "TEXT"
 	property.Value = "Value"
 	if property.GetCurrentValue("entityID123", entityMap) != "Value" {
-		t.Error("Expected TestPropertyGetCurrentValueString test case to pass")
+		t.Error("Expected TestPropertyGetCurrentValueStringText test case to pass")
+	}
+	property.DataType = "STRING"
+	property.Format = "JSON"
+	propertyValueJSON := make(map[string]interface{})
+	propertyValueJSON["key"] = "property value"
+	property.Value = propertyValueJSON
+	if !reflect.DeepEqual(property.GetCurrentValue("entityId123", entityMap), propertyValueJSON) {
+		t.Error("Expected TestPropertyGetCurrentValueStringJson test case to pass")
+	}
+	property.DataType = "STRING"
+	property.Format = "YAML"
+	property.Value = "men:\n  - John Smith\n  - Bill Jones\nwomen:\n  - Mary Smith\n  - Susan Williams"
+	if !reflect.DeepEqual(property.GetCurrentValue("entityId123", entityMap), property.GetValue()) {
+		t.Error("Expected TestPropertyGetCurrentValueStringYaml test case to pass")
 	}
 	property.DataType = "NUMERIC"
+	property.Format = ""
 	property.Value = float64(1)
 	if property.GetCurrentValue("entityID123", entityMap) != float64(1) {
 		t.Error("Expected TestPropertyGetCurrentValueNumeric test case to pass")

--- a/lib/internal/utils/UrlBuilder.go
+++ b/lib/internal/utils/UrlBuilder.go
@@ -99,7 +99,7 @@ func (ub *URLBuilder) GetWebSocketURL() string {
 
 // GetToken returns the string "Bearer <token>"
 func (ub *URLBuilder) GetToken() string {
-	req, _ := http.NewRequest("GET", "http://localhost", nil)
+	req, _ := http.NewRequest("GET", "https://localhost", nil)
 	var err error
 	err = ub.authenticator.Authenticate(req)
 	if err != nil {


### PR DESCRIPTION
Description of the PR - 

1. Added required changes for SDK to support json & yaml datatypes.
2. Version changed to 0.2.0
3. GetFeature, GetFeatures, GetProperty, GetProperties now return two values. (value, error)
4. Tightened the typecasting function when exported struct fields of Feature & Property were overridden to invalid values. SDK will not panic in such cases. And will return nil
5. Property receiver  renamed from `f` to `p`
6. Static scan issues fixed