### PR TITLE
Retries for failed API calls, updated usages count in metering to 10

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "^.secrets.baseline$|go.sum|examples/SampleApp/go.sum|vendor|.cra/.cveignore",
     "lines": null
   },
-  "generated_at": "2022-02-14T07:17:37Z",
+  "generated_at": "2022-03-25T03:45:37Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -70,7 +70,7 @@
         "hashed_secret": "d4c3d66fd0c38547a3c7a4c6bdc29c36911bc030",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 75,
+        "line_number": 74,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# IBM Cloud App Configuration Go server SDK 0.2.4
+# IBM Cloud App Configuration Go server SDK 0.2.5
 
 IBM Cloud App Configuration SDK is used to perform feature flag and property evaluation based on the configuration on
 IBM Cloud App Configuration service.

--- a/examples/.env
+++ b/examples/.env
@@ -1,0 +1,10 @@
+# For region, provide us-south for Dallas, eu-gb for London, au-syd for Sydney and us-east for Washington DC.
+REGION=
+GUID=
+APIKEY=
+
+# Environment id `dev` is the id of default environment created on instance creation.
+ENVIRONMENT_ID=dev
+COLLECTION_ID=car-rentals
+FEATURE_ID=weekend-discount
+PROPERTY_ID=users-location

--- a/examples/README.md
+++ b/examples/README.md
@@ -16,7 +16,7 @@
 
 - Go to dashboard page of App Configuration service instance in the IBM Cloud UI.
 - Navigate to Service Credentials section and generate a new set of credentials. Provide these generated `region`
-  , `guid` and `apikey` values in file [`main.go`](main.go#L22)
+  , `guid` and `apikey` values in [environment file](.env).
 
 ## Step 3: Create a collection, segment, feature flag & add targeting to feature flag
 
@@ -37,14 +37,14 @@ Collection ID: car-rentals
 
 Name: Users from Bangalore urban area
 Add rule one:
-Attribute name: city
-Operator: is
-Values: Bangalore
+            Attribute name: city
+            Operator: is
+            Values: Bangalore
 Add rule two:
-Attribute name: radius
-Operator: less than and equals
-Values: 60
-
+            Attribute name: radius
+            Operator: less than and equals
+            Values: 60
+            
 ```
 
 - Again on the same instance, navigate to Feature flags section and create a feature flag by clicking on create button.
@@ -67,7 +67,7 @@ Add this feature flag to the above collection created "Car Rentals"
 
 Name: User location
 Property ID: user-location
-Property type: String
+Property type & format: String & Text
 Default value: other
 Add this property to the above collection created "Car Rentals"
 ```
@@ -76,20 +76,17 @@ Add this property to the above collection created "Car Rentals"
 
 ```
 Select the segment "Users from Bangalore urban area" from the dropdown.
-Choose Override enabled value, and give some value(say 25) in the textarea.
-Click Save rule & Add the targeting.
+Click on radio button "Override" in the Enabled value section, and give some value(say 25) in the below numeric input.
+Next, click on "Save rule" & and then click on "Add targeting". This applies the targeting to the feature flag.
 ```
 
 - Click `Add targeting` on the property created & target this property to the segment.
 
 ```
 Select the segment "Users from Bangalore urban area" from the dropdown.
-Choose Override enabled value, and give the value(say "Bangalore") in the textarea.
-Click Save rule & Add the targeting.
+Click on radio button "Override" in the Property value section, and give the value(say "Bangalore") in the below text input.
+Next, click on "Save rule" & and then click on "Add targeting". This applies the targeting to the property.
 ```
-- Use the `id` of default environment created on instance creation.
-
-- In the example app, provide the collectionId, environmentId, featureId & propertyId in file [`main.go`](main.go#L23)
 
 ## Step 4: Run the app
 

--- a/examples/go.mod
+++ b/examples/go.mod
@@ -3,6 +3,7 @@ module examples
 go 1.16
 
 require (
-	github.com/IBM/appconfiguration-go-sdk v0.2.4
+	github.com/IBM/appconfiguration-go-sdk v0.2.5
 	github.com/gorilla/mux v1.7.2
+	github.com/joho/godotenv v1.4.0
 )

--- a/examples/go.sum
+++ b/examples/go.sum
@@ -47,6 +47,8 @@ github.com/hashicorp/go-hclog v0.9.2/go.mod h1:5CU+agLiy3J7N7QjHK5d05KxGsuXiQLrj
 github.com/hashicorp/go-retryablehttp v0.7.0 h1:eu1EI/mbirUgP5C8hVsTNaGZreBDlYiwC1FZWkvQPQ4=
 github.com/hashicorp/go-retryablehttp v0.7.0/go.mod h1:vAew36LZh98gCBJNLH42IQ1ER/9wtLZZ8meHqQvEYWY=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
+github.com/joho/godotenv v1.4.0 h1:3l4+N6zfMWnkbPEXKng2o2/MR5mSwTrBih4ZEkkz1lg=
+github.com/joho/godotenv v1.4.0/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
 github.com/klauspost/compress v1.13.6/go.mod h1:/3/Vjq9QcHkK5uEr5lBEmyoZ1iFhe47etQ6QUkpK6sk=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=

--- a/examples/main.go
+++ b/examples/main.go
@@ -3,10 +3,11 @@ package main
 
 import (
 	"fmt"
+	"github.com/gorilla/mux"
+	"github.com/joho/godotenv"
 	"log"
 	"net/http"
-
-	"github.com/gorilla/mux"
+	"os"
 
 	AppConfiguration "github.com/IBM/appconfiguration-go-sdk/lib"
 )
@@ -16,16 +17,26 @@ func homePage(w http.ResponseWriter, r *http.Request) {
 }
 
 func main() {
+	err := godotenv.Load(".env")
+	if err != nil {
+		panic(err)
+	}
+	region := os.Getenv("REGION")
+	guid := os.Getenv("GUID")
+	apikey := os.Getenv("APIKEY")
+	collectionId := os.Getenv("COLLECTION_ID")
+	environmentId := os.Getenv("ENVIRONMENT_ID")
+
 	appConfiguration := AppConfiguration.GetInstance()
-	appConfiguration.Init(AppConfiguration.REGION_US_SOUTH, "<guid>", "<apikey>")
-	appConfiguration.SetContext("<collectionId>", "<environmentId>")
+	appConfiguration.Init(region, guid, apikey)
+	appConfiguration.SetContext(collectionId, environmentId)
 	entityID := "user123"
 	entityAttributes := make(map[string]interface{})
 	entityAttributes["city"] = "Bangalore"
 	entityAttributes["radius"] = 60
 
 	fmt.Println("\n\nFEATURE FLAG OPERATIONS\n")
-	feature, err := appConfiguration.GetFeature("<featureId>")
+	feature, err := appConfiguration.GetFeature(os.Getenv("FEATURE_ID"))
 	if err == nil {
 		fmt.Println("Feature Name:", feature.GetFeatureName())
 		fmt.Println("Feature Id:", feature.GetFeatureID())
@@ -35,7 +46,7 @@ func main() {
 	}
 
 	fmt.Println("\n\nPROPERTY OPERATIONS\n")
-	property, err := appConfiguration.GetProperty("<propertyId>")
+	property, err := appConfiguration.GetProperty(os.Getenv("PROPERTY_ID"))
 	if err == nil {
 		fmt.Println("Property Name:", property.GetPropertyName())
 		fmt.Println("Property Id:", property.GetPropertyID())
@@ -46,6 +57,10 @@ func main() {
 	//So, to keep track of live changes to configurations use this listener.
 	appConfiguration.RegisterConfigurationUpdateListener(func() {
 		fmt.Println("configurations updated")
+		// To find the effect of any configuration changes, you should call the feature or property related methods again
+
+		// feature, err := appConfigClient.GetFeature("feature-id")
+		// newValue := feature.GetCurrentValue(entityID, entityAttributes)
 	})
 
 	myRouter := mux.NewRouter().StrictSlash(true)

--- a/lib/configurationhandler_test.go
+++ b/lib/configurationhandler_test.go
@@ -90,7 +90,7 @@ func TestFetchApi(t *testing.T) {
 		}))
 
 	ch := GetConfigurationHandlerInstance()
-	ch.urlBuilder.Init("collectionID", "environmentID", "region", "guid", "apikey", ts.URL)
+	ch.urlBuilder.SetBaseServiceURL(ts.URL)
 	ch.urlBuilder.SetAuthenticator(&core.NoAuthAuthenticator{})
 	ch.liveConfigUpdateEnabled = true
 	ch.fetchFromAPI()
@@ -111,7 +111,7 @@ func TestFetchApi(t *testing.T) {
 		}))
 
 	ch = GetConfigurationHandlerInstance()
-	ch.urlBuilder.Init("collectionID", "environmentID", "region", "guid", "apikey", ts.URL)
+	ch.urlBuilder.SetBaseServiceURL(ts.URL)
 	ch.urlBuilder.SetAuthenticator(&core.NoAuthAuthenticator{})
 	ch.liveConfigUpdateEnabled = true
 	ch.fetchFromAPI()
@@ -230,7 +230,7 @@ func TestStartWebSocket(t *testing.T) {
 
 	ch.urlBuilder = utils.GetInstance()
 
-	ch.urlBuilder.Init("collectionID", "environmentID", "region", "guid", "apikey", server2.URL)
+	ch.urlBuilder.SetBaseServiceURL(server2.URL)
 	ch.urlBuilder.SetWebSocketURL(webSocketURL)
 	ch.urlBuilder.SetAuthenticator(&core.NoAuthAuthenticator{})
 	ch.guid = "guid"

--- a/lib/internal/constants/constants.go
+++ b/lib/internal/constants/constants.go
@@ -23,10 +23,31 @@ const DefaultSegmentID = "$$null$$"
 const DefaultEntityID = "$$null$$"
 
 // DefaultUsageLimit : Default Usage Limit
-const DefaultUsageLimit = 25
+const DefaultUsageLimit = 10
 
 // UserAgent specifies the user agent name
-const UserAgent = "appconfiguration-go-sdk/0.2.4"
+const UserAgent = "appconfiguration-go-sdk/0.2.5"
 
 // ConfigurationFile : Name of file to which configurations will be written
 const ConfigurationFile = "appconfiguration.json"
+
+// MaxNumberOfRetries : Maximum number of retries
+const MaxNumberOfRetries = 3
+
+// MaxRetryInterval : Maximum duration between successive retries (in seconds)
+const MaxRetryInterval = 30
+
+// StatusCodeGET : Http status code for successful GET call
+const StatusCodeGET = 200
+
+// StatusCodePOST : Http status code for successful POST call
+const StatusCodePOST = 202
+
+// StatusCodeTooManyRequests : Http status code for API call exceeding rate limit
+const StatusCodeTooManyRequests = 429
+
+// StatusCodeServerErrorBegin : Beginning status code for server errors
+const StatusCodeServerErrorBegin = 500
+
+// StatusCodeServerErrorEnd : End status code for server errors
+const StatusCodeServerErrorEnd = 599

--- a/lib/internal/messages/Messages.go
+++ b/lib/internal/messages/Messages.go
@@ -234,3 +234,15 @@ const TypeCastingError = "Error Type casting. Check the feature or property valu
 
 // ContextOptionsParameterDeprecation = Deprecation message
 const ContextOptionsParameterDeprecation = "Deprecated: With v0.2.1 the existing method of passing ConfigurationFile will be deprecated & removed from v0.3.0 \nUse BootstrapFile parameter instead."
+
+// FetchAPISuccessful : FetchAPISuccessful const
+const FetchAPISuccessful = "Successfully fetched the configurations."
+
+// WebSocketConnectFailed : WebSocketConnectFailed const
+const WebSocketConnectFailed = "Socket connect failed. "
+
+// AuthTokenError : AuthTokenError const
+const AuthTokenError = "Invalid API Key is provided. Could not generate Bearer token for the provided API Key."
+
+// RetryScheduledMessage : RetryScheduledMessage const
+const RetryScheduledMessage = "Scheduled the API request to retry after 10 minutes."

--- a/lib/internal/utils/ApiManager.go
+++ b/lib/internal/utils/ApiManager.go
@@ -18,8 +18,10 @@ package utils
 
 import (
 	"encoding/json"
+	cons "github.com/IBM/appconfiguration-go-sdk/lib/internal/constants"
 	"github.com/IBM/go-sdk-core/v5/core"
 	"sync"
+	"time"
 )
 
 // APIManager : wrapper struct over core base service.
@@ -40,6 +42,7 @@ func GetAPIManagerInstance() *APIManager {
 			Authenticator: urlBuilderInstance.GetAuthenticator(),
 		}
 		apiManagerInstance.baseService, _ = core.NewBaseService(apiManagerInstance.serviceOptions)
+		apiManagerInstance.baseService.EnableRetries(cons.MaxNumberOfRetries, time.Second*time.Duration(cons.MaxRetryInterval))
 	})
 	return apiManagerInstance
 }

--- a/lib/internal/utils/FileManager.go
+++ b/lib/internal/utils/FileManager.go
@@ -23,10 +23,16 @@ import (
 	"github.com/IBM/appconfiguration-go-sdk/lib/internal/utils/log"
 	"io/ioutil"
 	"path"
+	"sync"
 )
+
+var fileMutex sync.Mutex
 
 // StoreFiles : Store Files
 func StoreFiles(content, filePath string) {
+	fileMutex.Lock()
+	defer fileMutex.Unlock()
+
 	log.Debug(messages.StoreFile)
 
 	file, err := json.MarshalIndent(json.RawMessage(content), "", "\t")
@@ -43,6 +49,9 @@ func StoreFiles(content, filePath string) {
 
 // ReadFiles reads file from the file path
 func ReadFiles(filePath string) []byte {
+	fileMutex.Lock()
+	defer fileMutex.Unlock()
+
 	log.Debug(messages.ReadFile)
 	file, err := ioutil.ReadFile(filePath)
 	if err != nil {

--- a/lib/internal/utils/UrlBuilder.go
+++ b/lib/internal/utils/UrlBuilder.go
@@ -17,10 +17,9 @@
 package utils
 
 import (
+	"github.com/IBM/go-sdk-core/v5/core"
 	"net/http"
 	"regexp"
-
-	"github.com/IBM/go-sdk-core/v5/core"
 )
 
 // URLBuilder : URLBuilder struct
@@ -89,6 +88,11 @@ func (ub *URLBuilder) Init(collectionID string, environmentID string, region str
 // GetBaseServiceURL returns base service url
 func (ub *URLBuilder) GetBaseServiceURL() string {
 	return ub.httpBase
+}
+
+// SetBaseServiceURL overrides the base service url if set
+func (ub *URLBuilder) SetBaseServiceURL(url string) {
+	ub.httpBase = url
 }
 
 // GetAuthenticator returns iam authenticator

--- a/lib/internal/utils/metering_test.go
+++ b/lib/internal/utils/metering_test.go
@@ -215,7 +215,7 @@ func TestSendToServer(t *testing.T) {
 	ts := httptest.NewServer(
 		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Content-type", "application/json")
-			w.WriteHeader(200)
+			w.WriteHeader(202)
 			fmt.Fprintf(w, "%s", `Success`)
 		}))
 

--- a/lib/internal/utils/urlbuilder_test.go
+++ b/lib/internal/utils/urlbuilder_test.go
@@ -17,6 +17,7 @@
 package utils
 
 import (
+	"github.com/IBM/go-sdk-core/v5/core"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -26,19 +27,19 @@ func TestURLBuilder(t *testing.T) {
 
 	// test when override server host is provided
 	urlBuilder := GetInstance()
-	urlBuilder.Init("CollectionID", "EnvironmentID", "region", "guid", "apikey", "overrideServerHost")
+	urlBuilder.SetWebSocketURL("wss://overrideServerHost/apprapp/wsfeature?instance_id=guid&collection_id=CollectionID&environment_id=EnvironmentID")
 	assert.Equal(t, "wss://overrideServerHost/apprapp/wsfeature?instance_id=guid&collection_id=CollectionID&environment_id=EnvironmentID", urlBuilder.GetWebSocketURL())
 	resetURLBuilderInstance()
 
 	// test when override server host is not provided
 	urlBuilder = GetInstance()
-	urlBuilder.Init("CollectionID", "EnvironmentID", "region", "guid", "apikey", "")
+	urlBuilder.SetBaseServiceURL("https://region.apprapp.cloud.ibm.com")
 	assert.Equal(t, "https://region.apprapp.cloud.ibm.com", urlBuilder.GetBaseServiceURL())
 	resetURLBuilderInstance()
 
 	// test when get token encounters an error while retrieving token and returns an token of size 0
 	urlBuilder = GetInstance()
-	urlBuilder.Init("CollectionID", "EnvironmentID", "region", "guid", "apikey", "")
+	urlBuilder.SetAuthenticator(&core.NoAuthAuthenticator{})
 	token := urlBuilder.GetToken()
 	assert.Equal(t, 0, len(token))
 	resetURLBuilderInstance()

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "postUpdateOptions": ["gomodTidy", "gomodUpdateImportPaths"],
+  "packageRules": [	
+    {	
+    "managers": [	
+        "gomod"	
+        ],
+      "force": {
+          "recreateClosed": true
+      },
+      "groupName": "GoLang Dependencies",
+      "labels": ["golang", "dependency-updater"]
+    }
+  ]
+}


### PR DESCRIPTION
- Enabled retries for failed API calls
- usages array length updated to 10 per API request payload
- changes for resubmitting the metering payload if it had failed even after retries
- Fix for not to retry socket dial for invalid apikey
- patch version of the sdk updated 0.2.5
- updated example app and its documentation