### PR TITLE
sanitize the user input

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "^.secrets.baseline$|go.sum|examples/SampleApp/go.sum|vendor|.cra/.cveignore",
     "lines": null
   },
-  "generated_at": "2022-03-25T03:45:37Z",
+  "generated_at": "2022-03-25T04:49:00Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"

--- a/lib/ConfigurationHandler.go
+++ b/lib/ConfigurationHandler.go
@@ -28,7 +28,7 @@ import (
 	"github.com/IBM/go-sdk-core/v5/core"
 	"github.com/gorilla/websocket"
 	"net/http"
-	"path"
+	"path/filepath"
 	"sync"
 	"time"
 )
@@ -92,7 +92,7 @@ func (ch *ConfigurationHandler) loadData() {
 		log.Error(messages.ConfigurationHandlerInitError)
 	}
 	if len(ch.persistentCacheDirectory) > 0 {
-		ch.persistentData = utils.ReadFiles(path.Join(ch.persistentCacheDirectory, constants.ConfigurationFile))
+		ch.persistentData = utils.ReadFiles(filepath.Join(utils.SanitizePath(ch.persistentCacheDirectory), constants.ConfigurationFile))
 		if !bytes.Equal(ch.persistentData, []byte(`{}`)) {
 			// no updating the listener here. Only updating cache is enough
 			ch.saveInCache(ch.persistentData)
@@ -102,7 +102,7 @@ func (ch *ConfigurationHandler) loadData() {
 		log.Debug(messages.BootstrapFileProvided)
 		if len(ch.persistentCacheDirectory) > 0 {
 			if bytes.Equal(ch.persistentData, []byte(`{}`)) {
-				bootstrapFileData := utils.ReadFiles(ch.bootstrapFile)
+				bootstrapFileData := utils.ReadFiles(utils.SanitizePath(ch.bootstrapFile))
 				go utils.StoreFiles(string(bootstrapFileData), ch.persistentCacheDirectory)
 				ch.updateCacheAndListener(bootstrapFileData)
 			} else {
@@ -112,7 +112,7 @@ func (ch *ConfigurationHandler) loadData() {
 				}
 			}
 		} else {
-			bootstrapFileData := utils.ReadFiles(ch.bootstrapFile)
+			bootstrapFileData := utils.ReadFiles(utils.SanitizePath(ch.bootstrapFile))
 			ch.updateCacheAndListener(bootstrapFileData)
 		}
 	}


### PR DESCRIPTION
The ContextOptions BootstrapFile & PersistentCacheDirectory are the user inputs to setContext() method. When user provides manipulated string path input such as `../../../etc.conf` which when resolved may lead to creating/reading the configuration file from unnecessary directories. This PR sanitizes such inputs before resolving the final path

Example
|Input to sanitize function|Output of it|
|-|-|
|../..////Users/home/Desktop/abc/..//|/Users/home/Desktop|
| /Users//home/Desktop/abc| /Users/home/Desktop/abc|
| ../../../../etc.conf/| /etc.conf|