### PR TITLE
changes to GetSecret() method

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@
 repos:
 - repo: git@github.ibm.com:Whitewater/whitewater-detect-secrets
   # If you desire to use a specific version of whitewater-detect-secrets, you can replace `master` with other git revisions such as branch, tag or commit sha.
-  rev: 0.13.1+ibm.57.dss
+  rev: 0.13.1+ibm.61.dss
   hooks:
     -   id: detect-secrets # pragma: whitelist secret
         # Add options for detect-secrets-hook binary. You can run `detect-secrets-hook --help` to list out all possible options.

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "^.secrets.baseline$|go.sum|vendor|.cra/.cveignore",
     "lines": null
   },
-  "generated_at": "2023-04-12T06:00:07Z",
+  "generated_at": "2023-06-16T06:52:36Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -61,7 +61,7 @@
     }
   ],
   "results": {},
-  "version": "0.13.1+ibm.58.dss",
+  "version": "0.13.1+ibm.61.dss",
   "word_list": {
     "file": null,
     "hash": null

--- a/examples/go.mod
+++ b/examples/go.mod
@@ -3,7 +3,7 @@ module examples
 go 1.16
 
 require (
-	github.com/IBM/appconfiguration-go-sdk v0.3.3
+	github.com/IBM/appconfiguration-go-sdk v0.4.0
 	github.com/gorilla/mux v1.7.2
 	github.com/joho/godotenv v1.4.0
 )

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.16
 
 require (
 	github.com/IBM/go-sdk-core/v5 v5.13.1
-	github.com/IBM/secrets-manager-go-sdk v1.0.49
+	github.com/IBM/secrets-manager-go-sdk/v2 v2.0.0
 	github.com/go-openapi/strfmt v0.21.7 // indirect
 	github.com/go-playground/validator/v10 v10.12.0 // indirect
 	github.com/gorilla/websocket v1.5.0

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,10 @@
 github.com/IBM/go-sdk-core/v5 v5.10.2/go.mod h1:WZPFasUzsKab/2mzt29xPcfruSk5js2ywAPwW4VJjdI=
 github.com/IBM/go-sdk-core/v5 v5.13.1 h1:zD6p3t1whAlRJo/VBmE69c8RcH9LCHL1n0/sO1MWlpw=
 github.com/IBM/go-sdk-core/v5 v5.13.1/go.mod h1:pVkN7IGmsSdmR1ZCU4E/cLcCclqRKMYgg7ya+O2Mk6g=
-github.com/IBM/secrets-manager-go-sdk v1.0.49 h1:wRxyjFpSoZz6brj55JSMk6Sb38dLrQYnsEKcdYibflo=
-github.com/IBM/secrets-manager-go-sdk v1.0.49/go.mod h1:QyDSznC6gJEXIGaj+JPxoEVtyXfkaxzId87mxcEb+vM=
+github.com/IBM/secrets-manager-go-sdk v1.2.0 h1:bgFfBF+LjHLtUfV3hTLkfgE8EjFsJaeU2icA2Hg+M50=
+github.com/IBM/secrets-manager-go-sdk v1.2.0/go.mod h1:qv+tQg8Z3Vb11DQYxDjEGeROHDtTLQxUWuOIrIdWg6E=
+github.com/IBM/secrets-manager-go-sdk/v2 v2.0.0 h1:Lx4Bvim/MfoHEYR+n312bty5DirAJypBGGS9YZo3zCw=
+github.com/IBM/secrets-manager-go-sdk/v2 v2.0.0/go.mod h1:jagqWmjZ0zUEqh5jdGB42ApSQS40fu2LWw6pdg8JJko=
 github.com/asaskevich/govalidator v0.0.0-20200907205600-7a23bdc65eef/go.mod h1:WaHUgvxTVq04UNunO+XhnAqY/wQc+bxr74GqbsZ/Jqw=
 github.com/asaskevich/govalidator v0.0.0-20210307081110-f21760c49a8d/go.mod h1:WaHUgvxTVq04UNunO+XhnAqY/wQc+bxr74GqbsZ/Jqw=
 github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 h1:DklsrG3dyBCFEj5IhUbnKptjxatkF07cF2ak3yi77so=

--- a/lib/AppConfiguration.go
+++ b/lib/AppConfiguration.go
@@ -23,7 +23,7 @@ import (
 	"github.com/IBM/appconfiguration-go-sdk/lib/internal/messages"
 	"github.com/IBM/appconfiguration-go-sdk/lib/internal/models"
 	"github.com/IBM/appconfiguration-go-sdk/lib/internal/utils/log"
-	sm "github.com/IBM/secrets-manager-go-sdk/secretsmanagerv1"
+	sm "github.com/IBM/secrets-manager-go-sdk/v2/secretsmanagerv2"
 )
 
 // AppConfiguration : Struct having init and configInstance.
@@ -80,7 +80,6 @@ func GetInstance() *AppConfiguration {
 // Example: AppConfiguration.OverrideServiceUrl("https://testurl.com")
 //
 // NOTE: To be used for development purposes only.
-//
 func OverrideServiceUrl(url string) {
 	overrideServiceUrl = url
 }
@@ -89,7 +88,7 @@ func OverrideServiceUrl(url string) {
 // by using a private endpoint that is accessible only through the IBM Cloud private network.
 // Be default, it is set to false.
 //
-//NOTE: This method must be called before calling the `Init` function on the SDK.
+// NOTE: This method must be called before calling the `Init` function on the SDK.
 func (ac *AppConfiguration) UsePrivateEndpoint(usePrivateEndpointParam bool) {
 	usePrivateEndpoint = usePrivateEndpointParam
 }
@@ -213,10 +212,10 @@ func (ac *AppConfiguration) GetProperties() (map[string]models.Property, error) 
 }
 
 // GetSecret : Get Secret
-func (ac *AppConfiguration) GetSecret(propertyID string, secretMangerObject *sm.SecretsManagerV1) (models.SecretProperty, error) {
+func (ac *AppConfiguration) GetSecret(propertyID string, secretsManagerService *sm.SecretsManagerV2) (models.SecretProperty, error) {
 	if ac.isInitializedConfig == true && ac.configurationHandlerInstance != nil {
-		if secretMangerObject != nil {
-			return ac.configurationHandlerInstance.getSecret(propertyID, secretMangerObject)
+		if secretsManagerService != nil {
+			return ac.configurationHandlerInstance.getSecret(propertyID, secretsManagerService)
 		} else {
 			log.Error(messages.InvalidSecretManagerMessage)
 			return models.SecretProperty{}, errors.New("error: " + messages.InvalidSecretManagerMessage)

--- a/lib/ConfigurationHandler.go
+++ b/lib/ConfigurationHandler.go
@@ -31,7 +31,7 @@ import (
 	"github.com/IBM/appconfiguration-go-sdk/lib/internal/utils"
 	"github.com/IBM/appconfiguration-go-sdk/lib/internal/utils/log"
 	"github.com/IBM/go-sdk-core/v5/core"
-	sm "github.com/IBM/secrets-manager-go-sdk/secretsmanagerv1"
+	sm "github.com/IBM/secrets-manager-go-sdk/v2/secretsmanagerv2"
 	"github.com/gorilla/websocket"
 )
 
@@ -308,13 +308,13 @@ func (ch *ConfigurationHandler) getProperty(propertyID string) (models.Property,
 }
 
 // GetSecret : Get Secret
-func (ch *ConfigurationHandler) getSecret(propertyID string, secretMangerObject *sm.SecretsManagerV1) (models.SecretProperty, error) {
+func (ch *ConfigurationHandler) getSecret(propertyID string, secretsManagerService *sm.SecretsManagerV2) (models.SecretProperty, error) {
 	property, err := ch.getProperty(propertyID)
 	if err != nil {
 		return models.SecretProperty{}, err
 	}
 	if property.GetPropertyDataType() == "SECRETREF" {
-		ch.cache.SecretManagerMap[propertyID] = secretMangerObject
+		ch.cache.SecretManagerMap[propertyID] = secretsManagerService
 		return models.SecretProperty{PropertyID: propertyID}, nil
 	}
 	log.Error("Invalid operation: GetSecret() cannot be called on a ", property.GetPropertyDataType(), " property.")

--- a/lib/internal/constants/constants.go
+++ b/lib/internal/constants/constants.go
@@ -26,7 +26,7 @@ const DefaultEntityID = "$$null$$"
 const DefaultUsageLimit = 10
 
 // UserAgent specifies the user agent name
-const UserAgent = "appconfiguration-go-sdk/0.3.3"
+const UserAgent = "appconfiguration-go-sdk/0.4.0"
 
 // ConfigurationFile : Name of file to which configurations will be written
 const ConfigurationFile = "appconfiguration.json"


### PR DESCRIPTION
- IBM cloud secrets manager has migrated their APIs to v2. This has impact on the [GetSecret()](https://github.com/IBM/appconfiguration-go-sdk/blob/f212098447c75e7e50a49d3ebef559e04b5c1833/lib/AppConfiguration.go#L216) method of this SDK. Necessary changes have been made to all the internal references of GetSecret() to work with secrets manager v2 initialised client.
- readme updates
- release version updated to v0.4.0 (minor release)