### PR TITLE
add support for eu-de region

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "^.secrets.baseline$|go.sum|vendor|.cra/.cveignore",
     "lines": null
   },
-  "generated_at": "2024-02-22T06:55:34Z",
+  "generated_at": "2024-03-16T19:17:48Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# IBM Cloud App Configuration Go server SDK 0.5.2
+# IBM Cloud App Configuration Go server SDK 0.5.3
 
 IBM Cloud App Configuration SDK is used to perform feature flag and property evaluation based on the configuration on
 IBM Cloud App Configuration service.
@@ -78,6 +78,7 @@ using **`AppConfiguration.GetInstance()`**. [See this example below](#fetching-t
     - `AppConfiguration.REGION_EU_GB` for London
     - `AppConfiguration.REGION_AU_SYD` for Sydney
     - `AppConfiguration.REGION_US_EAST` for Washington DC
+    - `AppConfiguration.REGION_EU_DE` for Frankfurt
 - guid : Instance Id of the App Configuration service. Obtain it from the service credentials section of the App
   Configuration dashboard.
 - apikey : ApiKey of the App Configuration service. Obtain it from the service credentials section of the App

--- a/examples/README.md
+++ b/examples/README.md
@@ -8,7 +8,7 @@
 - In the [IBM Cloud catalog](https://cloud.ibm.com/catalog#services), search **App Configuration** and
   select [App Configuration](https://cloud.ibm.com/catalog/services/app-configuration). The service configuration screen
   opens.
-- **Select a region** - Currently, Dallas (us-south), London (eu-gb), Sydney (au-syd) and Washington DC (us-east) regions are supported.
+- **Select a region** - Currently, Dallas (us-south), London (eu-gb), Sydney (au-syd), Washington DC (us-east) and Frankfurt (eu-de) regions are supported.
 - Select a pricing plan, resource group and configure your resource with a service name, or use the preset name.
 - Click **Create**. A new service instance is created and the App Configuration console displayed.
 

--- a/examples/go.mod
+++ b/examples/go.mod
@@ -3,7 +3,7 @@ module examples
 go 1.16
 
 require (
-	github.com/IBM/appconfiguration-go-sdk v0.5.2
+	github.com/IBM/appconfiguration-go-sdk v0.5.3
 	github.com/gorilla/mux v1.8.0
 	github.com/joho/godotenv v1.5.1
 )

--- a/lib/AppConfiguration.go
+++ b/lib/AppConfiguration.go
@@ -59,6 +59,9 @@ const REGION_AU_SYD = "au-syd"
 // REGION_US_EAST : Washington DC Region
 const REGION_US_EAST = "us-east"
 
+// REGION_EU_DE : Frankfurt Region
+const REGION_EU_DE = "eu-de"
+
 // GetInstance : Get App Configuration Instance
 func GetInstance() *AppConfiguration {
 	log.Debug(messages.RetrieveingAppConfig)

--- a/lib/internal/constants/constants.go
+++ b/lib/internal/constants/constants.go
@@ -26,7 +26,7 @@ const DefaultEntityID = "$$null$$"
 const DefaultUsageLimit = 10
 
 // UserAgent specifies the user agent name
-const UserAgent = "appconfiguration-go-sdk/0.5.2"
+const UserAgent = "appconfiguration-go-sdk/0.5.3"
 
 // ConfigurationFile : Name of file to which configurations will be written
 const ConfigurationFile = "appconfiguration.json"


### PR DESCRIPTION
- add SDK support for IBM Cloud region - `eu-de`
- bump SDK patch version. SDK new version is v0.5.3