### PR TITLE
Make sure `SetContext` behaves the same if its called repeatedly 

### DIFF
--- a/lib/AppConfiguration.go
+++ b/lib/AppConfiguration.go
@@ -159,13 +159,7 @@ func (ac *AppConfiguration) SetContext(collectionID string, environmentID string
 		return
 	}
 	ac.isInitializedConfig = true
-	// If the cache is not having data make a blocking call and load the data in in-memory cache , else use the existing cache data and asynchronously update it.
-	// This scenario can happen if the user uses setcontext second time in the code , in that case cache would not be empty.
-	if ac.configurationHandlerInstance.cache == nil {
-		ac.configurationHandlerInstance.loadData()
-	} else {
-		go ac.configurationHandlerInstance.loadData()
-	}
+	ac.configurationHandlerInstance.loadData()
 }
 
 // FetchConfigurations : Fetch Configurations


### PR DESCRIPTION
## Context
The documentation states the following
https://github.com/IBM/appconfiguration-go-sdk/blob/ab40613f9d0a6f9761c675583b9d6d6b761494b4/README.md?plain=1#L72-L73

However, for unit tests it is very helpful to call `SetContext` more than once to initialize the singleton instance with different bootstrap files. This does not reliably work today because `SetContext` spawns a goroutine to reload data when you call it repeatedly:
https://github.com/IBM/appconfiguration-go-sdk/blob/ab40613f9d0a6f9761c675583b9d6d6b761494b4/lib/AppConfiguration.go#L162-L168

As a consumer I need a synchronization point to know when data loading completed. This is not possible today.

## Proposed Changes
Align the behavior of `SetContext` so that it always calls `ac.configurationHandlerInstance.loadData()` synchronously. 

## Risk Assessment
In production use, I don't see the need to call it more than once (as stated in the documentation). That is, I don't see big risk involved in this change and it's backward-compatible.

Solves https://github.com/IBM/appconfiguration-go-sdk/issues/49